### PR TITLE
[PUBLIC] Support JWT 2.0 and multiple algorithms

### DIFF
--- a/lib/omniauth/strategies/jwt.rb
+++ b/lib/omniauth/strategies/jwt.rb
@@ -12,7 +12,7 @@ module OmniAuth
       args [:secret]
       
       option :secret, nil
-      option :algorithm, 'HS256'
+      option :decode_options, {}
       option :uid_claim, 'email'
       option :required_claims, %w(name email)
       option :info_map, {"name" => "name", "email" => "email"}
@@ -25,7 +25,7 @@ module OmniAuth
       
       def decoded
         begin
-          @decoded ||= ::JWT.decode(request.params['jwt'], options.secret, options.algorithm).first
+          @decoded ||= ::JWT.decode(request.params['jwt'], options.secret, true, options.decode_options).first
         rescue Exception => e
           raise BadJwt.new(e.message)
         end

--- a/omniauth-jwt.gemspec
+++ b/omniauth-jwt.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "rack-test"
   
-  spec.add_dependency "jwt"
+  spec.add_dependency "jwt", ">= 2.0.0"
   spec.add_dependency "omniauth", "~> 1.1"
 end

--- a/spec/lib/omniauth/strategies/jwt_spec.rb
+++ b/spec/lib/omniauth/strategies/jwt_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::JWT do
-  let(:response_json){ MultiJson.load(last_response.body) }
+  let(:response_json){ JSON.parse(last_response.body) }
   let(:args){ ['imasecret', {auth_url: 'http://example.com/login'}] }
-  
+
   let(:app){
     the_args = args
     Rack::Builder.new do |b|
@@ -12,7 +12,7 @@ describe OmniAuth::Strategies::JWT do
       b.run lambda{|env| [200, {}, [(env['omniauth.auth'] || {}).to_json]]}
     end
   }
-  
+
   context 'request phase' do
     it 'should redirect to the configured login url' do
       get '/auth/jwt'
@@ -20,41 +20,61 @@ describe OmniAuth::Strategies::JWT do
       expect(last_response.headers['Location']).to eq('http://example.com/login')
     end
   end
-  
+
   context 'callback phase' do
     it 'should decode the response' do
       encoded = JWT.encode({name: 'Bob', email: 'steve@example.com'}, 'imasecret')
       get '/auth/jwt/callback?jwt=' + encoded
       expect(response_json["info"]["email"]).to eq("steve@example.com")
     end
-    
+
     it 'should not work without required fields' do
       encoded = JWT.encode({name: 'Steve'}, 'imasecret')
       get '/auth/jwt/callback?jwt=' + encoded
       expect(last_response.status).to eq(302)
     end
-    
+
     it 'should assign the uid' do
       encoded = JWT.encode({name: 'Steve', email: 'dude@awesome.com'}, 'imasecret')
       get '/auth/jwt/callback?jwt=' + encoded
       expect(response_json["uid"]).to eq('dude@awesome.com')
     end
-    
+
+    context 'with a non-default encoding algorithm' do
+      let(:args){ ['imasecret', {auth_url: 'http://example.com/login', decode_options: { algorithms: ['HS512', 'HS256'] }}] }
+
+      it 'should decode the response with an allowed algorithm' do
+        encoded = JWT.encode({name: 'Bob', email: 'steve@example.com'}, 'imasecret', 'HS512')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(JSON.parse(last_response.body)["info"]["email"]).to eq("steve@example.com")
+
+        encoded = JWT.encode({name: 'Bob', email: 'steve@example.com'}, 'imasecret', 'HS256')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(JSON.parse(last_response.body)["info"]["email"]).to eq("steve@example.com")
+      end
+
+      it 'should fail decoding the response with a different algorithm' do
+        encoded = JWT.encode({name: 'Bob', email: 'steve@example.com'}, 'imasecret', 'HS384')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(last_response.headers["Location"]).to include("/auth/failure")
+      end
+    end
+
     context 'with a :valid_within option set' do
       let(:args){ ['imasecret', {auth_url: 'http://example.com/login', valid_within: 300}] }
-      
+
       it 'should work if the iat key is within the time window' do
         encoded = JWT.encode({name: 'Ted', email: 'ted@example.com', iat: Time.now.to_i}, 'imasecret')
         get '/auth/jwt/callback?jwt=' + encoded
         expect(last_response.status).to eq(200)
       end
-      
+
       it 'should not work if the iat key is outside the time window' do
         encoded = JWT.encode({name: 'Ted', email: 'ted@example.com', iat: Time.now.to_i + 500}, 'imasecret')
         get '/auth/jwt/callback?jwt=' + encoded
         expect(last_response.status).to eq(302)
       end
-      
+
       it 'should not work if the iat key is missing' do
         encoded = JWT.encode({name: 'Ted', email: 'ted@example.com'}, 'imasecret')
         get '/auth/jwt/callback?jwt=' + encoded

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $:.unshift File.dirname(__FILE__) + "/../lib"
 require 'rack/test'
+require 'json'
 
 require 'omniauth/jwt'
 OmniAuth.config.logger = Logger.new('/dev/null')


### PR DESCRIPTION
Since JWT 2.0 the signature verification checks that the algorithm
passed to `encode` is the same as the `alg` value in the token. If you
support multiple algorithms you can pass an `algorithms: []` option to
the `JWT.decode` call.

This updates the omniauth strategy to allow us passing multiple options
to the `decode` call to support multiple algorithms (and not just
HS256).

* https://github.com/jwt/ruby-jwt/pull/184