### PR TITLE
[🚨 PUBLIC REPO 🚨] Allow multiple claims to be used for OmniAuth JWT uids

### DIFF
--- a/lib/omniauth/strategies/jwt.rb
+++ b/lib/omniauth/strategies/jwt.rb
@@ -38,6 +38,8 @@ module OmniAuth
       end
 
       def callback_phase
+        raise ClaimInvalid.new("UID claim empty or missing") if uid.to_s.empty?
+
         super
       rescue BadJwt => e
         fail! 'bad_jwt', e
@@ -46,11 +48,7 @@ module OmniAuth
       end
 
       uid do
-        if options.uid_claim.is_a?(Array)
-          options.uid_claim.map { |field| decoded[field.to_s] }.compact.first
-        else
-          decoded[options.uid_claim]
-        end
+        Array(options.uid_claim).map { |field| decoded[field.to_s].to_s.strip }.reject(&:empty?).first
       end
 
       extra do

--- a/lib/omniauth/strategies/jwt.rb
+++ b/lib/omniauth/strategies/jwt.rb
@@ -6,11 +6,11 @@ module OmniAuth
     class JWT
       class ClaimInvalid < StandardError; end
       class BadJwt < StandardError; end
-      
+
       include OmniAuth::Strategy
-      
+
       args [:secret]
-      
+
       option :secret, nil
       option :decode_options, {}
       option :uid_claim, 'email'
@@ -18,11 +18,11 @@ module OmniAuth
       option :info_map, {"name" => "name", "email" => "email"}
       option :auth_url, nil
       option :valid_within, nil
-      
+
       def request_phase
         redirect options.auth_url
       end
-      
+
       def decoded
         begin
           @decoded ||= ::JWT.decode(request.params['jwt'], options.secret, true, options.decode_options).first
@@ -36,7 +36,7 @@ module OmniAuth
         raise ClaimInvalid.new("'iat' timestamp claim is too skewed from present.") if options.valid_within && (Time.now.to_i - @decoded["iat"]).abs > options.valid_within
         @decoded
       end
-      
+
       def callback_phase
         super
       rescue BadJwt => e
@@ -44,13 +44,19 @@ module OmniAuth
       rescue ClaimInvalid => e
         fail! :claim_invalid, e
       end
-      
-      uid{ decoded[options.uid_claim] }
-      
+
+      uid do
+        if options.uid_claim.is_a?(Array)
+          options.uid_claim.map { |field| decoded[field.to_s] }.compact.first
+        else
+          decoded[options.uid_claim]
+        end
+      end
+
       extra do
         {:raw_info => decoded}
       end
-      
+
       info do
         options.info_map.inject({}) do |h,(k,v)|
           h[k.to_s] = decoded[v.to_s]
@@ -58,7 +64,7 @@ module OmniAuth
         end
       end
     end
-    
+
     class Jwt < JWT; end
   end
 end

--- a/omniauth-jwt.gemspec
+++ b/omniauth-jwt.gemspec
@@ -23,8 +23,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
+  spec.add_development_dependency "rack"
   spec.add_development_dependency "rack-test"
-  
+  spec.add_development_dependency "rack-session"
+
   spec.add_dependency "jwt", ">= 2.0.0"
   spec.add_dependency "omniauth", "~> 1.1"
 end

--- a/spec/lib/omniauth/strategies/jwt_spec.rb
+++ b/spec/lib/omniauth/strategies/jwt_spec.rb
@@ -7,7 +7,7 @@ describe OmniAuth::Strategies::JWT do
   let(:app){
     the_args = args
     Rack::Builder.new do |b|
-      b.use Rack::Session::Cookie, secret: 'sekrit'
+      b.use Rack::Session::Cookie, secret: 'sekrit' * 11
       b.use OmniAuth::Strategies::JWT, *the_args
       b.run lambda{|env| [200, {}, [(env['omniauth.auth'] || {}).to_json]]}
     end
@@ -38,6 +38,27 @@ describe OmniAuth::Strategies::JWT do
       encoded = JWT.encode({name: 'Steve', email: 'dude@awesome.com'}, 'imasecret')
       get '/auth/jwt/callback?jwt=' + encoded
       expect(response_json["uid"]).to eq('dude@awesome.com')
+    end
+
+    context 'with multiple uid_claim options' do
+      let(:args){ ['imasecret', {auth_url: 'http://example.com/login', uid_claim: ['sub', 'email']}] }
+
+      it "should assign the first uid_claim that's present" do
+        encoded = JWT.encode({name: 'Bob', sub: 'with-sub', email: 'steve@example.com'}, 'imasecret')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(JSON.parse(last_response.body)["uid"]).to eq("with-sub")
+
+        encoded = JWT.encode({name: 'Bob', email: 'steve@example.com'}, 'imasecret')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(JSON.parse(last_response.body)["uid"]).to eq("steve@example.com")
+      end
+
+      it "fails if no valid claim is present" do
+        encoded = JWT.encode({name: 'Bob', last_name: 'steve@example.com'}, 'imasecret')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(last_response.status).to eq(302)
+        expect(last_response.headers['Location']).to match('auth/failure')
+      end
     end
 
     context 'with a non-default encoding algorithm' do

--- a/spec/lib/omniauth/strategies/jwt_spec.rb
+++ b/spec/lib/omniauth/strategies/jwt_spec.rb
@@ -51,10 +51,26 @@ describe OmniAuth::Strategies::JWT do
         encoded = JWT.encode({name: 'Bob', email: 'steve@example.com'}, 'imasecret')
         get '/auth/jwt/callback?jwt=' + encoded
         expect(JSON.parse(last_response.body)["uid"]).to eq("steve@example.com")
+
+        encoded = JWT.encode({name: 'Bob', sub: '', email: 'steve@example.com'}, 'imasecret')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(JSON.parse(last_response.body)["uid"]).to eq("steve@example.com")
       end
 
       it "fails if no valid claim is present" do
         encoded = JWT.encode({name: 'Bob', last_name: 'steve@example.com'}, 'imasecret')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(last_response.status).to eq(302)
+        expect(last_response.headers['Location']).to match('auth/failure')
+      end
+
+      it "fails if no valid claim is an empty string" do
+        encoded = JWT.encode({name: 'Bob', last_name: 'Alice', email: ''}, 'imasecret')
+        get '/auth/jwt/callback?jwt=' + encoded
+        expect(last_response.status).to eq(302)
+        expect(last_response.headers['Location']).to match('auth/failure')
+
+        encoded = JWT.encode({name: 'Bob', last_name: 'Alice', sub: ''}, 'imasecret')
         get '/auth/jwt/callback?jwt=' + encoded
         expect(last_response.status).to eq(302)
         expect(last_response.headers['Location']).to match('auth/failure')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $:.unshift File.dirname(__FILE__) + "/../lib"
 require 'rack/test'
+require 'rack/session'
 require 'json'
 
 require 'omniauth/jwt'
@@ -14,7 +15,7 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  
+
   include Rack::Test::Methods
 
   # Run specs in random order to surface order dependencies. If you find an


### PR DESCRIPTION
# 🚨 PUBLIC REPO! 🚨

Allow multiple `uid_claim`s to be used

This commit allows us to configure multiple claims to be used as UID.
This will allow us to support `sub` (which is OPTIONAL) as `auth.uid`
while still falling back to the user's email.